### PR TITLE
[PATCH] sepolicy: changes for lvm support

### DIFF
--- a/attributes
+++ b/attributes
@@ -76,3 +76,6 @@ attribute binderservicedomain;
 
 # All domains used for tad service.
 attribute tad_placeholder;
+
+# All domains used for lvm service.
+attribute lvm_placeholder;

--- a/domain.te
+++ b/domain.te
@@ -194,11 +194,12 @@ neverallow {
   -init
   -ueventd
   -vold
+  -lvm_placeholder
 } self:capability mknod;
 
 attribute rmt_placeholder;
 # Limit raw I/O to these whitelisted domains.
-neverallow { domain -kernel -init -recovery -ueventd -watchdogd -healthd -vold -uncrypt -tee -rmt_placeholder } self:capability sys_rawio;
+neverallow { domain -kernel -init -recovery -ueventd -watchdogd -healthd -vold -uncrypt -tee -rmt_placeholder -lvm_placeholder } self:capability sys_rawio;
 
 # No process can map low memory (< CONFIG_LSM_MMAP_MIN_ADDR).
 neverallow domain self:memprotect mmap_zero;
@@ -248,14 +249,14 @@ neverallow domain kernel:security setbool;
 neverallow { domain -init } kernel:security setsecparam;
 
 # Only init, ueventd and system_server should be able to access HW RNG
-neverallow { domain -init -system_server -ueventd } hw_random_device:chr_file *;
+neverallow { domain -init -system_server -ueventd -lvm_placeholder } hw_random_device:chr_file *;
 
 # Ensure that all entrypoint executables are in exec_type.
 neverallow domain { file_type -exec_type }:file entrypoint;
 
 # Ensure that nothing in userspace can access /dev/mem or /dev/kmem
-neverallow { domain -rmt_placeholder -kernel -ueventd -init } kmem_device:chr_file *;
-neverallow { domain -rmt_placeholder } kmem_device:chr_file ~{ create relabelto unlink setattr };
+neverallow { domain -rmt_placeholder -kernel -ueventd -init -lvm_placeholder } kmem_device:chr_file *;
+neverallow { domain -rmt_placeholder -lvm_placeholder } kmem_device:chr_file ~{ create relabelto unlink setattr };
 
 # Only init should be able to configure kernel usermodehelpers or
 # security-sensitive proc settings.
@@ -271,18 +272,20 @@ neverallow domain init:binder *;
 
 # Don't allow raw read/write/open access to block_device
 # Rather force a relabel to a more specific type
-neverallow { domain -kernel -init -recovery -vold -uncrypt -tad_placeholder } block_device:blk_file { open read write };
+
+neverallow { domain -kernel -init -recovery -vold -uncrypt -tad_placeholder -lvm_placeholder} block_device:blk_file { open read write };
 
 # Don't allow raw read/write/open access to generic devices.
 # Rather force a relabel to a more specific type.
 # init is exempt from this as there are character devices that only it uses.
 # ueventd is exempt from this, as it is managing these devices.
-neverallow { domain -init -ueventd } device:chr_file { open read write };
+neverallow { domain -init -ueventd -lvm_placeholder } device:chr_file { open read write };
 
 # Limit what domains can mount filesystems or change their mount flags.
 # sdcard_type / vfat is exempt as a larger set of domains need
 # this capability, including device-specific domains.
-neverallow { domain -kernel -init -recovery -zygote -vold -sudaemon  } { fs_type -sdcard_type }:filesystem { mount remount relabelfrom relabelto };
+
+neverallow { domain -kernel -init -recovery -zygote -vold -sudaemon -lvm_placeholder } { fs_type -sdcard_type }:filesystem { mount remount relabelfrom relabelto };
 
 #
 # Assert that, to the extent possible, we're not loading executable content from
@@ -318,7 +321,7 @@ neverallow domain { system_file exec_type }:dir_file_class_set mounton;
 
 # Nothing should be writing to files in the rootfs.
 ifelse(shipping_build, `true',
-  `neverallow domain rootfs:file { create write setattr relabelto append unlink link rename };'
+  `neverallow { domain -lvm_placeholder } rootfs:file { create write setattr relabelto append unlink link rename };'
 ,
 )
 

--- a/init.te
+++ b/init.te
@@ -286,8 +286,8 @@ unix_socket_connect(init, vold, vold)
 
 # The init domain is only entered via setcon from the kernel domain,
 # never via an exec-based transition.
-neverallow domain init:process dyntransition;
-neverallow { domain -kernel} init:process transition;
+neverallow { domain -lvm_placeholder } init:process dyntransition;
+neverallow { domain -kernel -lvm_placeholder } init:process transition;
 neverallow init { file_type fs_type -init_exec }:file entrypoint;
 
 # Never read/follow symlinks created by shell or untrusted apps.


### PR DESCRIPTION
PS2:
    allow lvm device:chr_file { read write open };
    allow lvm block_device:blk_file { read open };
    allow lvm lvm:capability { mknod };

PS3:
    allow lvm labeledfs:filesystem { mount };
    allow lvm lvm:capability { sys_rawio };

PS4:
    move lvm-placeholder attribute to attributes file.
    fix build for non lvm devices.

PS5,6:
    fix code style and commit message.

Change-Id: Ia237e70f7f74cd12406b722ad2b9b673475f3a28
Signed-off-by: Alexander Martinz eviscerationls@gmail.com

Conflicts:
    attributes
    domain.te
